### PR TITLE
fix: Update Claude Code review workflow to checkout PR head

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,10 +25,12 @@ jobs:
       issues: read
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
- Fixes Claude Code review workflow to properly checkout PR head instead of merge ref
- Adds support for cross-fork PRs by specifying repository and token parameters
- Ensures Claude Code reviews against actual PR changes rather than merge artifacts

## Changes
- Updated checkout action name from "Checkout repository" to "Checkout PR head"
- Changed `ref` from `refs/pull/${{ github.event.number }}/merge` to `${{ github.event.pull_request.head.ref }}`
- Added `repository: ${{ github.event.pull_request.head.repo.full_name }}` parameter
- Added `token: ${{ secrets.GITHUB_TOKEN }}` parameter

## Test plan
- [ ] Verify workflow runs correctly on new PRs
- [ ] Test cross-fork PR support
- [ ] Confirm Claude Code can access proper file changes

🤖 Generated with [Claude Code](https://claude.ai/code)