### PR TITLE
Slash commands bug

### DIFF
--- a/components/frontend/src/app/projects/[name]/rfe/[id]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/[id]/page.tsx
@@ -338,16 +338,6 @@ export default function ProjectRFEDetailPage() {
                         ? ((workflow as unknown as { jiraLinks?: Array<{ path: string; jiraKey: string }> }).jiraLinks || []).find(l => l.path === expected)?.jiraKey
                         : undefined;
                       const sessionForPhase = rfeSessions.find(s => (s.metadata.labels)?.["rfe-phase"] === phase);
-                     
-                      const prerequisitesMet = phase === "ideate"
-                        ? true
-                        : phase === "specify"
-                        ? true
-                        : phase === "plan"
-                        ? specKitDir.spec.exists
-                        : phase === "tasks"
-                        ? (specKitDir.spec.exists && specKitDir.plan.exists)
-                        : (specKitDir.spec.exists && specKitDir.plan.exists && specKitDir.tasks.exists);
                       const sessionDisplay = (sessionForPhase && typeof (sessionForPhase as AgenticSession).spec?.displayName === 'string')
                         ? String((sessionForPhase as AgenticSession).spec.displayName)
                         : sessionForPhase?.metadata.name;
@@ -380,7 +370,11 @@ export default function ProjectRFEDetailPage() {
                                 <span className="text-sm font-medium">Ready</span>
                               </div>
                             ) : (
-                              <Badge variant="secondary">{prerequisitesMet ? "Missing" : "Blocked"}</Badge>
+                              <span className="text-xs text-muted-foreground italic">
+                                {phase === "plan" ? "requires spec.md" :
+                                 phase === "tasks" ? "requires plan.md" :
+                                 phase === "implement" ? "requires tasks.md" : ""}
+                              </span>
                             )}
                             {!exists && (
                               phase === "ideate"
@@ -456,7 +450,7 @@ export default function ProjectRFEDetailPage() {
                                         } finally {
                                           setStartingPhase(null);
                                         }
-                                      }} disabled={startingPhase === phase || !prerequisitesMet || !isSeeded}>
+                                      }} disabled={startingPhase === phase || !isSeeded}>
                                         {startingPhase === phase ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" />Starting…</>) : (<><Play className="mr-2 h-4 w-4" />Start Chat</>)}
                                       </Button>
                                     )
@@ -523,7 +517,7 @@ export default function ProjectRFEDetailPage() {
                                       } finally {
                                         setStartingPhase(null);
                                       }
-                                    }} disabled={startingPhase === phase || !prerequisitesMet || !isSeeded}>
+                                    }} disabled={startingPhase === phase || !isSeeded}>
                                       {startingPhase === phase ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" />Starting…</>) : (<><Play className="mr-2 h-4 w-4" />Generate</>)}
                                     </Button>
                                 )

--- a/components/operator/main.go
+++ b/components/operator/main.go
@@ -733,7 +733,12 @@ func monitorJob(jobName, sessionName, sessionNamespace string) {
 				"message":        "Job completed successfully",
 				"completionTime": time.Now().Format(time.RFC3339),
 			})
-			_ = deleteJobAndPerJobService(sessionNamespace, jobName, sessionName)
+// DEBUG: Temporarily commented for debugging
+			if os.Getenv("DEBUG_KEEP_PODS") != "true" {
+				_ = deleteJobAndPerJobService(sessionNamespace, jobName, sessionName)
+			} else {
+				log.Printf("DEBUG_KEEP_PODS=true: Skipping cleanup of job %s", jobName)
+			}
 			return
 		}
 
@@ -787,7 +792,12 @@ func monitorJob(jobName, sessionName, sessionNamespace string) {
 						"message":        "Job completed successfully",
 						"completionTime": time.Now().Format(time.RFC3339),
 					})
+// DEBUG: Temporarily commented for debugging
+				if os.Getenv("DEBUG_KEEP_PODS") != "true" {
 					_ = deleteJobAndPerJobService(sessionNamespace, jobName, sessionName)
+				} else {
+					log.Printf("DEBUG_KEEP_PODS=true: Skipping cleanup of job %s", jobName)
+				}
 					return
 				}
 				// Non-zero exit = failure

--- a/components/runners/claude-code-runner/pyproject.toml
+++ b/components/runners/claude-code-runner/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "aiohttp>=3.8.0",
   "pyjwt>=2.8.0",
   "anthropic>=0.68.0",
-  "claude-agent-sdk>=0.1.0"
+  "claude-code-sdk>=0.0.23"
 ]
 
 [tool.uv]

--- a/components/runners/claude-code-runner/wrapper.py
+++ b/components/runners/claude-code-runner/wrapper.py
@@ -111,12 +111,12 @@ class ClaudeCodeAdapter:
             }
 
     async def _run_claude_agent_sdk(self, prompt: str):
-        """Execute the Claude Agent SDK with the given prompt."""
+        """Execute the Claude Code SDK with the given prompt."""
         try:
-            from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+            from claude_code_sdk import ClaudeSDKClient, ClaudeCodeOptions
             api_key = self.context.get_env('ANTHROPIC_API_KEY', '')
             if not api_key:
-                raise RuntimeError("ANTHROPIC_API_KEY is required for Claude Agent SDK")
+                raise RuntimeError("ANTHROPIC_API_KEY is required for Claude Code SDK")
 
             # Determine cwd and additional dirs from multi-repo config
             repos_cfg = self._get_repos_config()
@@ -146,7 +146,7 @@ class ClaudeCodeAdapter:
                     if p != cwd_path:
                         add_dirs.append(p)
 
-            options = ClaudeAgentOptions(cwd=cwd_path, permission_mode="acceptEdits", allowed_tools=["Read","Write","Bash","Glob","Grep","Edit","MultiEdit","WebSearch","WebFetch"])
+            options = ClaudeCodeOptions(cwd=cwd_path, permission_mode="acceptEdits", allowed_tools=["Read","Write","Bash","Glob","Grep","Edit","MultiEdit","WebSearch","WebFetch"])
             # Best-effort set add_dirs if supported by SDK version
             try:
                 if add_dirs:
@@ -185,7 +185,7 @@ class ClaudeCodeAdapter:
             result_payload = None
             self._turn_count = 0
             # Import SDK message and content types for accurate mapping
-            from claude_agent_sdk import (
+            from claude_code_sdk import (
                 AssistantMessage,
                 UserMessage,
                 SystemMessage,
@@ -311,7 +311,7 @@ class ClaudeCodeAdapter:
                 "stderr": ""
             }
         except Exception as e:
-            logging.error(f"Failed to run Claude Agent SDK: {e}")
+            logging.error(f"Failed to run Claude Code SDK: {e}")
             return {
                 "success": False,
                 "error": str(e)


### PR DESCRIPTION
* This restores the /specify, /plan, /tasks, /implement function - claude-code-sdk supports /slash commands while claude-agent-sdk does not afaict. We can bring back claude-agent-sdk but need to provide a wrapper/replacement to support the /slash commands we depend on. 
* Adds DEBUG_KEEP_PODS to add to operator deployment to keep failed agenticsessions from cleaning up, for dev/testing
* Removes the 'Blocked/Missing' from the UI for each phase, replace with a check upon session start - if prereq files aren't found in repo, fails with a useful message. We can probably improve this UX but for now, this is our only option. 